### PR TITLE
Ensure job panics on the correct error

### DIFF
--- a/bin/cmd/run.go
+++ b/bin/cmd/run.go
@@ -5,16 +5,16 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
+ 3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -65,7 +65,7 @@ var runCmd = &cobra.Command{
 
 		db[config.Sum] = *config.Script
 		writeErr := db.WriteDatabase(dbFile)
-		if err != nil {
+		if writeErr != nil {
 			panic(writeErr)
 		}
 


### PR DESCRIPTION
We want the `run` command to panic if it can't write to the DB so we have a big, loud, huge error to investigate.

What _actually_ happens is that if the task that `vc` runs exists abnormally, then our error check panics on that instead.

And if, in fact, writing to DB succeeds then the message we panic out on is just a simple `nil`.